### PR TITLE
기존 API Req/Res 인증 서버 연동 & useEffect 언마운트 경고 해결

### DIFF
--- a/domain/Course/CourseList/index.tsx
+++ b/domain/Course/CourseList/index.tsx
@@ -20,6 +20,8 @@ export default function CourseList(): JSX.Element {
       const res = await getCourses();
       setCourseItems(res);
     })();
+
+    return () => setCourseItems([]);
   }, []);
 
   return (

--- a/domain/Todo/SelectCourse/index.tsx
+++ b/domain/Todo/SelectCourse/index.tsx
@@ -37,8 +37,8 @@ export default function SelectCourse({ courseOnChange }: props): JSX.Element {
     (async () => {
       const res = await getCourses();
       setCourseItems(res);
-      return () => setCourseItems([]);
     })();
+    return () => setCourseItems([]);
   }, []);
 
   useEffect(() => {

--- a/libs/course/index.ts
+++ b/libs/course/index.ts
@@ -1,9 +1,32 @@
 import { apiClient } from "../api-client";
-
 import { CourseItem } from "../../types/components-type/course";
+import { getLocalStorageAccessToken, TokenRefresh } from "../oauth";
+import axios from "axios";
 
 export async function postNewCourse(course: CourseItem): Promise<void> {
-  await apiClient.post(`/courses`, course);
+  async function work() {
+    const accessToken = getLocalStorageAccessToken();
+    await apiClient.post(`/courses`, course, {
+      headers: {
+        Authorization: `${accessToken}`,
+      },
+    });
+  }
+  try {
+    return await work();
+  } catch (error) {
+    if (error instanceof Error) {
+      if (axios.isAxiosError(error)) {
+        switch (error.response?.status) {
+          case 401:
+            // 재시도: 리프레쉬 토큰으로 엑세스 토큰을 다시 발급
+            await TokenRefresh();
+            return await work();
+        }
+      }
+    }
+    throw new Error("postNewCourse() 에러");
+  }
 }
 
 export async function getCourses(): Promise<CourseItem[]> {

--- a/libs/todo/index.ts
+++ b/libs/todo/index.ts
@@ -31,6 +31,6 @@ export async function postNewTodo(todo: TodoItem): Promise<void> {
         }
       }
     }
-    throw new Error("postNewCourse() 에러");
+    throw new Error("postNewTodo() 에러");
   }
 }

--- a/libs/todo/index.ts
+++ b/libs/todo/index.ts
@@ -1,6 +1,8 @@
 import { apiClient } from "../api-client";
 
 import { TodoItem } from "../../types/components-type/todo";
+import { getLocalStorageAccessToken, TokenRefresh } from "../oauth";
+import axios from "axios";
 
 export async function getTodayTodos(): Promise<TodoItem[]> {
   const { data } = await apiClient.get<TodoItem[]>(`/work-todos`);
@@ -8,5 +10,27 @@ export async function getTodayTodos(): Promise<TodoItem[]> {
 }
 
 export async function postNewTodo(todo: TodoItem): Promise<void> {
-  await apiClient.post<TodoItem>(`/work-todos`, todo);
+  async function work() {
+    const accessToken = getLocalStorageAccessToken();
+    await apiClient.post<TodoItem>(`/work-todos`, todo, {
+      headers: {
+        Authorization: `${accessToken}`,
+      },
+    });
+  }
+  try {
+    return await work();
+  } catch (error) {
+    if (error instanceof Error) {
+      if (axios.isAxiosError(error)) {
+        switch (error.response?.status) {
+          case 401:
+            // 재시도: 리프레쉬 토큰으로 엑세스 토큰을 다시 발급
+            await TokenRefresh();
+            return await work();
+        }
+      }
+    }
+    throw new Error("postNewCourse() 에러");
+  }
 }


### PR DESCRIPTION
# 변경 내역
1. 코스 추가에 인증 헤더 추가
2. 할일 추가에 인증 헤더 추가
3. useEffect 언마운트 경고 해결

# 기능 추가 사유
API 인증 로직 사용을 위한 변경

# 테스트 시나리오
/new-course 코스 추가
/유저?tab=courseList 추가한 코스가 나오는지 확인
/new-todo 할일 추가
/유저?tab=todayTodo 추가한 할일이 나오는지 확인