### PR TITLE
한일 보기 & 코스 헤더 오류 수정 & Storage Server 요청 방식 변경 & 기존 인증 헤더 방식 변경

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_API_GATEWAY_URL=https://api-gateway.qa.belf.xyz
-NEXT_PUBLIC_OAUTH_SERVER_URL=https://oauth.qa.belf.xyz
-NEXT_PUBLIC_STORAGE_SERVER_URL=https://storage.qa.belf.xyz 
+NEXT_PUBLIC_OAUTH_SERVER_URL=http://localhost:8080
+NEXT_PUBLIC_STORAGE_SERVER_URL=https://storage.qa.belf.xyz

--- a/.env.development
+++ b/.env.development
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_API_GATEWAY_URL=https://api-gateway.qa.belf.xyz
-NEXT_PUBLIC_OAUTH_SERVER_URL=http://localhost:8080
-NEXT_PUBLIC_STORAGE_SERVER_URL=https://storage.qa.belf.xyz
+NEXT_PUBLIC_OAUTH_SERVER_URL=https://oauth.qa.belf.xyz
+NEXT_PUBLIC_STORAGE_SERVER_URL=https://storage.qa.belf.xyz 

--- a/domain/Course/Detail/CourseDetailNavigate/index.tsx
+++ b/domain/Course/Detail/CourseDetailNavigate/index.tsx
@@ -32,12 +32,12 @@ export default function CourseDetailNavigate({ setTabKey }: props): JSX.Element 
       showText: "한일",
       uri: "?tab=doneTodoList",
     },
-    {
-      key: "repeatList",
-      isSelect: false,
-      showText: "반복 할일",
-      uri: "?tab=repeatList",
-    },
+    // {
+    //   key: "repeatList",
+    //   isSelect: false,
+    //   showText: "반복 할일",
+    //   uri: "?tab=repeatList",
+    // },
   ]);
 
   useEffect(() => {
@@ -58,7 +58,7 @@ export default function CourseDetailNavigate({ setTabKey }: props): JSX.Element 
       <S.ScrollBox>
         <S.TabItemsBox>
           {tabList.map((tab: TabInfoType, index: number) => (
-            <Link scroll={false} href={"/courses/" + (router.query?.courseId ?? "0") + tab.uri} key={"tab" + index} passHref={true}>
+            <Link scroll={false} href={`/${router.query?.userEmail}/${router.query?.courseId ?? "0"}${tab.uri}`} key={"tab" + index} passHref={true}>
               <S.TabItemBox isSelect={tab.isSelect} onClick={() => clickedTab(tab.key)}>
                 <S.Text>{tab.showText}</S.Text>
               </S.TabItemBox>

--- a/domain/Course/Detail/Done/DoneItem/index.tsx
+++ b/domain/Course/Detail/Done/DoneItem/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import * as S from "./style";
+
+import ArrowIcon from "../../../../../icons/ArrowIcon";
+import CheckIcon from "../../../../../icons/CheckIcon";
+import { DoneItem as DoneItemType } from "../../../../../types/components-type/todo";
+import Link from "next/link";
+
+type props = {
+  doneItem: DoneItemType;
+  uri: string;
+};
+
+export default function DoneItem({ doneItem, uri }: props): JSX.Element {
+  return (
+    <Link href={uri}>
+      <S.TodoItemBox>
+        <S.CheckIconBox>
+          <CheckIcon />
+        </S.CheckIconBox>
+        <S.InfoBox>
+          <S.TextBox>
+            <S.TodoText>{doneItem.title}</S.TodoText>
+          </S.TextBox>
+          <S.TextBox>
+            <S.ExpranationText>{doneItem.actionDate ?? ""}</S.ExpranationText>
+          </S.TextBox>
+          <S.ArrowBox>
+            <ArrowIcon />
+          </S.ArrowBox>
+        </S.InfoBox>
+      </S.TodoItemBox>
+    </Link>
+  );
+}

--- a/domain/Course/Detail/Done/DoneItem/style.ts
+++ b/domain/Course/Detail/Done/DoneItem/style.ts
@@ -1,0 +1,59 @@
+import styled from "styled-components";
+
+const TodoItemBox = styled.button`
+  height: 60px;
+  width: 100%;
+  padding: 10px 20px;
+  display: flex;
+  background-color: ${({ theme }) => theme.backgroundColor.card};
+  border-radius: ${({ theme }) => theme.common.borderRadius.default}px;
+  position: relative;
+`;
+
+const InfoBox = styled.div`
+  padding-left: 6px;
+  width: 100%;
+  position: relative;
+`;
+
+const CheckIconBox = styled.div`
+  svg {
+    fill: ${({ theme }) => theme.brandColor.main};
+    max-width: 20px;
+    min-width: 20px;
+    width: 20px;
+    height: 20px;
+    display: inline-block;
+  }
+`;
+
+const TextBox = styled.div`
+  height: 20px;
+  width: 100%;
+`;
+
+const TodoText = styled.a`
+  font-size: ${({ theme }) => theme.common.fontSize.s200}px;
+  color: ${({ theme }) => theme.fontColor.main};
+  float: left;
+  height: 20px;
+  line-height: 20px;
+`;
+
+const ExpranationText = styled.a`
+  font-size: ${({ theme }) => theme.common.fontSize.s200}px;
+  color: ${({ theme }) => theme.fontColor.sub};
+  vertical-align: top;
+  float: left;
+  height: 20px;
+  line-height: 20px;
+`;
+
+const ArrowBox = styled.div`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 0;
+`;
+
+export { CheckIconBox, ExpranationText, InfoBox, TextBox, TodoItemBox, TodoText, ArrowBox };

--- a/domain/Course/Detail/Done/DoneList/index.tsx
+++ b/domain/Course/Detail/Done/DoneList/index.tsx
@@ -1,0 +1,41 @@
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+import { getDones } from "../../../../../libs/work-done";
+import { DoneItem as DoneItemType } from "../../../../../types/components-type/todo";
+import DoneItem from "../DoneItem";
+
+import * as S from "./style";
+
+export default function DoneList(): JSX.Element {
+  const [doneItems, setDoneItems] = useState<DoneItemType[]>([]);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const res = await getDones(parseInt(router.query?.courseId as string, 10));
+      setDoneItems(res.reverse());
+    })();
+    return () => setDoneItems([]);
+  }, []);
+
+  return (
+    <>
+      <S.TitleBox>
+        <S.Title>한일</S.Title>
+      </S.TitleBox>
+      <S.TodoBox>
+        {doneItems.length === 0 ? (
+          <a>한일을 작성해주세요</a>
+        ) : (
+          <>
+            {doneItems.map((doneItem, i) => {
+              const uri = `/${router.query?.userEmail}/${router.query?.courseId}/done/${doneItem.id}/post`;
+              return <DoneItem key={i} doneItem={doneItem} uri={uri} />;
+            })}
+          </>
+        )}
+      </S.TodoBox>
+    </>
+  );
+}

--- a/domain/Course/Detail/Done/DoneList/style.ts
+++ b/domain/Course/Detail/Done/DoneList/style.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+const TodoBox = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+`;
+
+const TitleBox = styled.div`
+  height: 40px;
+  margin-top: 20px;
+`;
+
+const Title = styled.a`
+  font-size: ${({ theme }) => theme.common.fontSize.s600}px;
+  font-weight: ${({ theme }) => theme.common.fontWeight.bold};
+  color: ${({ theme }) => theme.fontColor.main};
+`;
+
+export { Title, TitleBox, TodoBox };

--- a/domain/Course/Detail/DoneTab/index.tsx
+++ b/domain/Course/Detail/DoneTab/index.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import DoneList from "../Done/DoneList";
+
+export default function DoneTab(): JSX.Element {
+  return (
+    <>
+      <DoneList />
+    </>
+  );
+}

--- a/domain/Course/Detail/TodoItem/index.tsx
+++ b/domain/Course/Detail/TodoItem/index.tsx
@@ -19,7 +19,7 @@ type props = {
 
 export default function TodoItem({ todoItem, isLastItem, isDoneTodo }: props): JSX.Element {
   const userInfo = useRecoilValue(userInfoState);
-  const uri = isDoneTodo ? `/` : `/${userInfo.email}/${todoItem.courseId}/${todoItem.id}/post-work-done`;
+  const uri = isDoneTodo ? `/` : `/${userInfo.email}/${todoItem.courseId}/todo/${todoItem.id}/write`;
   return (
     <Link href={uri} passHref={true}>
       <S.TodoItemBox>

--- a/domain/Editer/PostMaster/index.tsx
+++ b/domain/Editer/PostMaster/index.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from "react";
+import * as S from "./style";
+
+import { DoneItem } from "../../../types/components-type/todo";
+import PostNodeList from "../PostNodeList";
+
+type props = {
+  postDoneItem: DoneItem;
+};
+
+export default function PostMaster({ postDoneItem }: props): JSX.Element {
+  const [doneItem] = useState<DoneItem>(postDoneItem);
+
+  return (
+    <S.Box>
+      <S.TitleBox>
+        <S.Title>{postDoneItem.title}</S.Title>
+      </S.TitleBox>
+      <S.Body>
+        <PostNodeList nodeList={doneItem.content} />
+      </S.Body>
+    </S.Box>
+  );
+}

--- a/domain/Editer/PostMaster/style.ts
+++ b/domain/Editer/PostMaster/style.ts
@@ -1,0 +1,26 @@
+import styled from "styled-components";
+
+const Box = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+`;
+
+const TitleBox = styled.div`
+  height: 40px;
+  margin-top: 20px;
+`;
+
+const Title = styled.a`
+  font-size: ${({ theme }) => theme.common.fontSize.s600}px;
+  font-weight: ${({ theme }) => theme.common.fontWeight.bold};
+  color: ${({ theme }) => theme.fontColor.main};
+`;
+
+const Body = styled.div`
+  background-color: ${({ theme }) => theme.backgroundColor.card};
+  border-radius: ${({ theme }) => theme.common.borderRadius.default}px;
+  padding: 6px 10px;
+`;
+
+export { Box, Title, TitleBox, Body };

--- a/domain/Editer/PostNodeItem/index.tsx
+++ b/domain/Editer/PostNodeItem/index.tsx
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+import * as S from "./style";
+
+import { EditNode, ImageNode, TextNode } from "../../../types/components-type/editer";
+
+type props = {
+  node: EditNode;
+};
+
+export default function PostNodeItem({ node }: props): JSX.Element {
+  const [item] = useState<EditNode>(node);
+
+  return <S.Box>{item.type == "text" ? <a>{(item.contents as TextNode).text}</a> : <img src={(item.contents as ImageNode).url} />}</S.Box>;
+}

--- a/domain/Editer/PostNodeItem/index.tsx
+++ b/domain/Editer/PostNodeItem/index.tsx
@@ -11,5 +11,5 @@ type props = {
 export default function PostNodeItem({ node }: props): JSX.Element {
   const [item] = useState<EditNode>(node);
 
-  return <S.Box>{item.type == "text" ? <a>{(item.contents as TextNode).text}</a> : <img src={(item.contents as ImageNode).url} />}</S.Box>;
+  return <S.Box>{item.type == "text" ? <a>{(item.contents as TextNode).text}</a> : <S.Image src={(item.contents as ImageNode).url} />}</S.Box>;
 }

--- a/domain/Editer/PostNodeItem/style.ts
+++ b/domain/Editer/PostNodeItem/style.ts
@@ -6,4 +6,9 @@ const Box = styled.div`
   row-gap: 10px;
 `;
 
-export { Box };
+const Image = styled.img`
+  max-width: 100%;
+  height: auto;
+`;
+
+export { Box, Image };

--- a/domain/Editer/PostNodeItem/style.ts
+++ b/domain/Editer/PostNodeItem/style.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const Box = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+`;
+
+export { Box };

--- a/domain/Editer/PostNodeList/index.tsx
+++ b/domain/Editer/PostNodeList/index.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+import * as S from "./style";
+
+import { EditNode } from "../../../types/components-type/editer";
+import PostNodeItem from "../PostNodeItem";
+
+type props = {
+  nodeList: EditNode[];
+};
+
+export default function WriteNodeList({ nodeList }: props): JSX.Element {
+  const [content] = useState<EditNode[]>(nodeList);
+
+  return (
+    <S.Box>
+      {content.map((nodeItem) => (
+        <PostNodeItem key={`node_${nodeItem.id}`} node={nodeItem} />
+      ))}
+    </S.Box>
+  );
+}

--- a/domain/Editer/PostNodeList/style.ts
+++ b/domain/Editer/PostNodeList/style.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const Box = styled.div`
+  display: flex;
+  flex-direction: column;
+  row-gap: 10px;
+`;
+
+export { Box };

--- a/domain/Todo/TodayTodoItem/index.tsx
+++ b/domain/Todo/TodayTodoItem/index.tsx
@@ -16,7 +16,7 @@ type props = {
 export default function TodayTodoItem({ todoItem, isLastItem }: props): JSX.Element {
   const userInfo = useRecoilValue(userInfoState);
   return (
-    <Link href={`/${userInfo.email}/${todoItem.courseId}/${todoItem.id}/post-work-done`} passHref={true}>
+    <Link href={`/${userInfo.email}/${todoItem.courseId}/todo/${todoItem.id}/write`} passHref={true}>
       <S.TodoItemBox>
         <S.Color backgroundColor={todoItem.color} />
         <S.InfoBox>

--- a/libs/course/index.ts
+++ b/libs/course/index.ts
@@ -8,7 +8,7 @@ export async function postNewCourse(course: CourseItem): Promise<void> {
     const accessToken = getLocalStorageAccessToken();
     await apiClient.post(`/courses`, course, {
       headers: {
-        Authorization: `${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
   }

--- a/libs/course/index.ts
+++ b/libs/course/index.ts
@@ -35,6 +35,11 @@ export async function getCourses(userId?: number, courseId?: number): Promise<Co
   return data;
 }
 
+export async function getCourse(courseId: number): Promise<CourseItem[]> {
+  const { data } = await apiClient.get<CourseItem[]>(`/courses/${courseId}`);
+  return data;
+}
+
 export async function deleteCourse(id: number): Promise<void> {
   await apiClient.delete(`/courses`, { data: { id } });
 }

--- a/libs/storage/index.ts
+++ b/libs/storage/index.ts
@@ -9,12 +9,11 @@ export async function postFile(file: File, onUploadProgress: (progressEvent: any
       onUploadProgress: onUploadProgress,
       headers: {
         Authorization: `Bearer ${accessToken}`,
+        "Content-Type": file.type,
       },
     };
-    const data = new FormData();
-    data.append("file", file);
 
-    const res = await storageClient.post(`/upload`, data, config);
+    const res = await storageClient.post("/upload", file, config);
     return res;
   }
   try {

--- a/libs/todo/index.ts
+++ b/libs/todo/index.ts
@@ -25,7 +25,7 @@ export async function postNewTodo(todo: TodoItem): Promise<void> {
     const accessToken = getLocalStorageAccessToken();
     await apiClient.post<TodoItem>(`/work-todos`, todo, {
       headers: {
-        Authorization: `${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
   }

--- a/libs/work-done/index.ts
+++ b/libs/work-done/index.ts
@@ -40,3 +40,9 @@ export async function getDone(doneId: number): Promise<DoneItem> {
   const { data } = await apiClient.get<DoneItem>(`/work-dones/${doneId}`);
   return data;
 }
+
+export async function getDones(courseId?: number): Promise<DoneItem[]> {
+  const queryString = [courseId && `courseId=${courseId}`];
+  const { data } = await apiClient.get<DoneItem[]>(`/work-dones?${queryString.join("&")}`);
+  return data;
+}

--- a/libs/work-done/index.ts
+++ b/libs/work-done/index.ts
@@ -2,6 +2,7 @@ import { apiClient } from "../api-client";
 
 import { getLocalStorageAccessToken, TokenRefresh } from "../oauth";
 import axios from "axios";
+import { DoneItem } from "../../types/components-type/todo";
 
 type WorkDone = {
   workTodoId: number;
@@ -15,7 +16,7 @@ export async function postWorkDone(workDone: WorkDone): Promise<void> {
     const accessToken = getLocalStorageAccessToken();
     await apiClient.post<WorkDone>(`/work-dones`, workDone, {
       headers: {
-        Authorization: `${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
   }
@@ -33,4 +34,9 @@ export async function postWorkDone(workDone: WorkDone): Promise<void> {
     }
     throw new Error("postWorkDone() 에러");
   }
+}
+
+export async function getDone(doneId: number): Promise<DoneItem> {
+  const { data } = await apiClient.get<DoneItem>(`/work-dones/${doneId}`);
+  return data;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "front-server",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "front-server",
   "version": "0.8.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "build:qa": "env-cmd -f .env.qa next build",
     "build:prod": "env-cmd -f .env.prod next build",

--- a/pages/[userEmail]/[courseId]/done/[doneId]/post/index.tsx
+++ b/pages/[userEmail]/[courseId]/done/[doneId]/post/index.tsx
@@ -1,0 +1,43 @@
+import { GetServerSideProps, InferGetServerSidePropsType, NextPage } from "next";
+import React, { useState } from "react";
+
+import UserCheck from "../../../../../../components/UserCheck";
+
+import { CourseItem } from "../../../../../../types/components-type/course";
+import { DoneItem } from "../../../../../../types/components-type/todo";
+
+import { getCourse } from "../../../../../../libs/course";
+import { getDone } from "../../../../../../libs/work-done";
+
+import CourseHeader from "../../../../../../domain/Course/Detail/CourseHeader";
+import PostWorkDoneLayout from "../../../../../../layouts/PostWorkDoneLayout";
+import { EditNode } from "../../../../../../types/components-type/editer";
+import PostMaster from "../../../../../../domain/Editer/PostMaster";
+
+const PostWorkDonePage: NextPage = ({ currentCourse, currentDone }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const [course] = useState<CourseItem>(currentCourse);
+  const [done] = useState<DoneItem>(currentDone);
+
+  // const userInfo = useRecoilValue(userInfoState);
+
+  return (
+    <UserCheck>
+      <PostWorkDoneLayout>
+        <CourseHeader courseItem={course} />
+        <PostMaster postDoneItem={done} />
+      </PostWorkDoneLayout>
+    </UserCheck>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { params } = context;
+  const resCourse = await getCourse(parseInt(params?.courseId as string, 10));
+  const resDone = await getDone(parseInt(params?.doneId as string, 10));
+  const content: EditNode[] = JSON.parse((resDone.content as unknown) as string);
+  resDone.content = content;
+
+  return { props: { currentCourse: resCourse[0], currentDone: resDone } };
+};
+
+export default PostWorkDonePage;

--- a/pages/[userEmail]/[courseId]/index.tsx
+++ b/pages/[userEmail]/[courseId]/index.tsx
@@ -12,16 +12,17 @@ import UserCheck from "../../../components/UserCheck";
 import TodoTab from "../../../domain/Course/Detail/TodoTab";
 import { userInfoState } from "../../../states/app";
 import { useRecoilValue } from "recoil";
-import { getCourses } from "../../../libs/course";
+import { getCourse } from "../../../libs/course";
 import { useRouter } from "next/router";
 import { CourseItem } from "../../../types/components-type/course";
+import DoneTab from "../../../domain/Course/Detail/DoneTab";
 
 const getTabComponent = (key: string) => {
   switch (key) {
     case "todo":
       return <TodoTab />;
     case "doneTodoList":
-      return <></>;
+      return <DoneTab />;
     case "repeatList":
       return <></>;
   }
@@ -40,7 +41,7 @@ const CourseDetailPage: NextPage = () => {
       return;
     }
     (async () => {
-      const res = await getCourses(userInfo.id, parseInt(router.query?.courseId as string, 10));
+      const res = await getCourse(parseInt(router.query?.courseId as string, 10));
       setCurrentCourse(res[0]);
     })();
 

--- a/pages/[userEmail]/[courseId]/todo/[todoId]/write/index.tsx
+++ b/pages/[userEmail]/[courseId]/todo/[todoId]/write/index.tsx
@@ -7,7 +7,7 @@ import UserCheck from "../../../../../../components/UserCheck";
 import CourseHeader from "../../../../../../domain/Course/Detail/CourseHeader";
 import EditerMaster from "../../../../../../domain/Editer/EditerMaster";
 import PostWorkDoneLayout from "../../../../../../layouts/PostWorkDoneLayout";
-import { getCourses } from "../../../../../../libs/course";
+import { getCourse } from "../../../../../../libs/course";
 import { getTodo } from "../../../../../../libs/todo";
 import { userInfoState } from "../../../../../../states/app";
 import { CourseItem } from "../../../../../../types/components-type/course";
@@ -25,7 +25,7 @@ const WriteWorkDonePage: NextPage = () => {
       return;
     }
     (async () => {
-      const resCourse = await getCourses(userInfo.id, parseInt(router.query?.courseId as string, 10));
+      const resCourse = await getCourse(parseInt(router.query?.courseId as string, 10));
       setCurrentCourse(resCourse[0]);
 
       const resTodo = await getTodo(parseInt(router.query?.todoId as string, 10));

--- a/pages/[userEmail]/[courseId]/todo/[todoId]/write/index.tsx
+++ b/pages/[userEmail]/[courseId]/todo/[todoId]/write/index.tsx
@@ -2,18 +2,18 @@ import { NextPage } from "next";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
-import UserCheck from "../../../../../components/UserCheck";
+import UserCheck from "../../../../../../components/UserCheck";
 
-import CourseHeader from "../../../../../domain/Course/Detail/CourseHeader";
-import EditerMaster from "../../../../../domain/Editer/EditerMaster";
-import PostWorkDoneLayout from "../../../../../layouts/PostWorkDoneLayout";
-import { getCourses } from "../../../../../libs/course";
-import { getTodo } from "../../../../../libs/todo";
-import { userInfoState } from "../../../../../states/app";
-import { CourseItem } from "../../../../../types/components-type/course";
-import { TodoItem } from "../../../../../types/components-type/todo";
+import CourseHeader from "../../../../../../domain/Course/Detail/CourseHeader";
+import EditerMaster from "../../../../../../domain/Editer/EditerMaster";
+import PostWorkDoneLayout from "../../../../../../layouts/PostWorkDoneLayout";
+import { getCourses } from "../../../../../../libs/course";
+import { getTodo } from "../../../../../../libs/todo";
+import { userInfoState } from "../../../../../../states/app";
+import { CourseItem } from "../../../../../../types/components-type/course";
+import { TodoItem } from "../../../../../../types/components-type/todo";
 
-const PostWorkDonePage: NextPage = () => {
+const WriteWorkDonePage: NextPage = () => {
   const [currentCourse, setCurrentCourse] = useState<CourseItem>({});
   const [currentWorkTodo, setCurrentWorkTodo] = useState<TodoItem>({});
 
@@ -45,4 +45,4 @@ const PostWorkDonePage: NextPage = () => {
   );
 };
 
-export default PostWorkDonePage;
+export default WriteWorkDonePage;

--- a/types/components-type/todo/index.ts
+++ b/types/components-type/todo/index.ts
@@ -1,3 +1,5 @@
+import { EditNode } from "../editer";
+
 export type TodoItem = {
   id?: number;
   recurringCycleDate?: number;
@@ -9,4 +11,12 @@ export type TodoItem = {
   courseTitle?: string;
   color?: string;
   repeatedDaysOfTheWeek?: number[];
+};
+
+export type DoneItem = {
+  id?: number;
+  title?: string;
+  content?: EditNode[];
+  workTodoId?: number;
+  userId?: number;
 };

--- a/types/components-type/todo/index.ts
+++ b/types/components-type/todo/index.ts
@@ -19,4 +19,5 @@ export type DoneItem = {
   content?: EditNode[];
   workTodoId?: number;
   userId?: number;
+  actionDate?: string;
 };


### PR DESCRIPTION
# 추가 내역

1. 한일 보기

# 추가 사유

1. 한일 보기 - 할일 추가 후 Read 페이지 필요

# 변경 내역

1. 코스 헤더 오류 수정
2. Storage Server 요청 방식 변경
3. 기존 인증 헤더 방식 변경

# 변경 사유

1. 코스 헤더 오류 수정 - 기존 헤더가 이상하게 표시되는 경우 존재
2. Storage Server 요청 방식 변경 - storage server의 변경 사항에 따른 요청 변경
3. 기존 인증 헤더 방식 변경 - 기존 인증 헤더에 Bearer 추가가 필요

# 테스트 시나리오

1. 생성된 한일을 작성 후 게시 확인
2. 한일을 작성 시 이미지가 정상적으로 업로드가 되는지 확인
3. 코스 디테일, 한일 작성, 한일 보기에 코스 정보가 정상적으로 표시되는지 확인
4. 코스 디테일의 한일 탭에 정상적으로 표시 되는지 확인
5. 기존 한일 추가, 코스 추가, 한일 작성이 정상적으로 작동되는지 확인