### PR TITLE
사용자 프로필 사진 업로드, 회원 탈퇴 기능 추가

### DIFF
--- a/components/LoginUser.tsx
+++ b/components/LoginUser.tsx
@@ -19,7 +19,7 @@ export default function LoginUser({ children }: Props): JSX.Element {
       try {
         const accessToken = getLocalStorageAccessToken();
 
-        if (accessToken === "") {
+        if (!accessToken) {
           setLoginUser(null);
           return;
         }

--- a/domain/Course/CourseList/index.tsx
+++ b/domain/Course/CourseList/index.tsx
@@ -42,7 +42,7 @@ export default function CourseList(): JSX.Element {
         )}
       </S.TitleBox>
       {courseItems.length === 0 ? (
-        <a>코스를 생성해주세요</a>
+        <a>코스를 생성해주세요.</a>
       ) : (
         <S.CourseListBox>
           {courseItems.map((courseItem, i) => (

--- a/domain/Course/CoursePinList/index.tsx
+++ b/domain/Course/CoursePinList/index.tsx
@@ -29,7 +29,7 @@ export default function CoursePinList(): JSX.Element {
         <S.Title>코스 리스트</S.Title>
       </S.TitleBox>
       {courseItems.length === 0 ? (
-        <a>코스를 생성해주세요</a>
+        <a>코스를 생성해주세요.</a>
       ) : (
         <S.CourseListBox>
           {courseItems.map((courseItem, i) => (

--- a/domain/Course/Detail/Done/DoneList/index.tsx
+++ b/domain/Course/Detail/Done/DoneList/index.tsx
@@ -22,11 +22,11 @@ export default function DoneList(): JSX.Element {
   return (
     <>
       <S.TitleBox>
-        <S.Title>한일</S.Title>
+        <S.Title>한 일</S.Title>
       </S.TitleBox>
       <S.TodoBox>
         {doneItems.length === 0 ? (
-          <a>한일을 작성해주세요</a>
+          <a>한 일을 작성해주세요.</a>
         ) : (
           <>
             {doneItems.map((doneItem, i) => {

--- a/domain/Course/Detail/TodoList/index.tsx
+++ b/domain/Course/Detail/TodoList/index.tsx
@@ -48,17 +48,17 @@ export default function TodoList({ isDoneTodo, currentDate }: Props): JSX.Elemen
       <S.TitleBox>
         <S.Title>{isDoneTodo ? "한 일" : "할 일"}</S.Title>
       </S.TitleBox>
-      <S.TodoBox>
-        {todoItems.length === 0 ? (
-          <a>{isDoneTodo ? "한 일" : "할 일"}을 생성해주세요</a>
-        ) : (
-          <>
+      {todoItems.length === 0 ? (
+        <a>{isDoneTodo ? "한 일" : "할 일"}을 생성해주세요.</a>
+      ) : (
+        <>
+          <S.TodoBox>
             {todoItems.map((todoItem, i) => (
               <TodoItem key={"todo" + i} todoItem={todoItem} isLastItem={todoItems.length - 1 == i} isDoneTodo={isDoneTodo} />
             ))}
-          </>
-        )}
-      </S.TodoBox>
+          </S.TodoBox>
+        </>
+      )}
     </>
   );
 }

--- a/domain/Setting/EditButton/style.ts
+++ b/domain/Setting/EditButton/style.ts
@@ -11,7 +11,7 @@ const Box = styled.div`
 const PopupBox = styled.div<{ isOpen: boolean }>`
   visibility: ${(props) => (props.isOpen ? "visible" : "hidden")};
   position: absolute;
-  width: 120px;
+  width: 140px;
   border-radius: 4px;
   background-color: ${({ theme }) => theme.backgroundColor.bg};
   border: 1px solid ${({ theme }) => theme.lineColor.main};

--- a/domain/Setting/SettingMaster/index.tsx
+++ b/domain/Setting/SettingMaster/index.tsx
@@ -1,6 +1,6 @@
 import { useRecoilState } from "recoil";
 import Button from "../../../components/Button";
-import { UsersAvatarUpload } from "../../../libs/oauth";
+import { UsersAvatarRemove, UsersAvatarUpload } from "../../../libs/oauth";
 import { loginUserState } from "../../../states/app";
 import { imageDefault } from "../../UserPage/UserProfile";
 import EditButton from "../EditButton";
@@ -10,7 +10,7 @@ import * as S from "./style";
 export default function SettingMaster(): JSX.Element {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
 
-  async function loadFile(event: any) {
+  async function loadAvatar(event: any) {
     try {
       const target = event.target as HTMLInputElement;
       const file = target.files[0];
@@ -25,7 +25,23 @@ export default function SettingMaster(): JSX.Element {
 
       await UsersAvatarUpload(file);
     } catch (error) {
-      alert("사용자 사진 업로드 도중 에러: " + error);
+      alert("사용자 사진 업로드 중 에러: " + error);
+    }
+  }
+
+  async function removeAvatar() {
+    try {
+      // 낙관론적 업데이트
+      setLoginUser((prev) => {
+        return {
+          ...prev,
+          avatarImage: imageDefault,
+        };
+      });
+
+      await UsersAvatarRemove();
+    } catch (error) {
+      alert("사용자 사진 삭제 중 에러: " + error);
     }
   }
 
@@ -39,7 +55,7 @@ export default function SettingMaster(): JSX.Element {
               menuItems={[
                 {
                   showText: "이미지 업로드",
-                  onClick: () => {
+                  onClick() {
                     const image = document.querySelector("#chooseFile");
                     const ev = new MouseEvent("click", { bubbles: true });
                     image.dispatchEvent(ev);
@@ -47,8 +63,8 @@ export default function SettingMaster(): JSX.Element {
                 },
                 {
                   showText: "이미지 삭제",
-                  onClick: () => {
-                    console.log("이미지 삭제 이벤트");
+                  onClick() {
+                    removeAvatar();
                   },
                 },
               ]}
@@ -75,7 +91,7 @@ export default function SettingMaster(): JSX.Element {
           </S.OptionButtonBox>
         </S.SettingOptionBox>
       </S.SettingOptionListBox>
-      <input type="file" id="chooseFile" name="chooseFile" accept="image/*" style={{ display: "none" }} onChange={loadFile} />
+      <input type="file" id="chooseFile" name="chooseFile" accept="image/*" style={{ display: "none" }} onChange={loadAvatar} />
     </S.Box>
   );
 }

--- a/domain/Setting/SettingMaster/index.tsx
+++ b/domain/Setting/SettingMaster/index.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from "next/router";
+import { useState } from "react";
 import { useRecoilState } from "recoil";
 import Button from "../../../components/Button";
+import Loading from "../../../components/Loading";
 import { UserRemove, UsersAvatarRemove, UsersAvatarUpload } from "../../../libs/oauth";
 import { loginUserState } from "../../../states/app";
 import { imageDefault } from "../../UserPage/UserProfile";
@@ -11,10 +13,13 @@ import * as S from "./style";
 export default function SettingMaster(): JSX.Element {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
 
+  const [isImgLoading, setIsImgLoading] = useState<boolean>();
+
   const router = useRouter();
 
   async function loadAvatar(event: any) {
     try {
+      setIsImgLoading(true);
       const target = event.target as HTMLInputElement;
       const file = target.files[0];
 
@@ -27,6 +32,7 @@ export default function SettingMaster(): JSX.Element {
       });
 
       await UsersAvatarUpload(file);
+      setIsImgLoading(false);
     } catch (error) {
       alert("사용자 사진 업로드 중 에러: " + error);
     }
@@ -34,6 +40,7 @@ export default function SettingMaster(): JSX.Element {
 
   async function removeAvatar() {
     try {
+      setIsImgLoading(true);
       // 낙관론적 업데이트
       setLoginUser((prev) => {
         return {
@@ -43,6 +50,7 @@ export default function SettingMaster(): JSX.Element {
       });
 
       await UsersAvatarRemove();
+      setIsImgLoading(false);
     } catch (error) {
       alert("사용자 사진 삭제 중 에러: " + error);
     }
@@ -61,7 +69,13 @@ export default function SettingMaster(): JSX.Element {
     <S.Box>
       <S.UserInfoBox>
         <S.UserImageBox>
-          <img src={loginUser.avatarImage ? loginUser.avatarImage : imageDefault} />
+          {isImgLoading ? (
+            <>
+              <Loading width="140px" height="140px" />
+            </>
+          ) : (
+            <img src={loginUser.avatarImage ? loginUser.avatarImage : imageDefault} />
+          )}
           <S.ImageEditButtonBox>
             <EditButton
               menuItems={[

--- a/domain/Setting/SettingMaster/index.tsx
+++ b/domain/Setting/SettingMaster/index.tsx
@@ -79,13 +79,15 @@ export default function SettingMaster(): JSX.Element {
       <S.Line />
       <S.SettingOptionListBox>
         <S.SettingOptionBox>
-          <S.OptionTitleText>회원탈퇴</S.OptionTitleText>
           <S.OptionButtonBox>
             <Button
-              text="회원탈퇴"
+              text="회원 탈퇴"
               bg="#FF5446"
               onClick={() => {
-                console.log("회원탈퇴 이벤트");
+                const result = confirm("회원 탈퇴를 진행하시겠습니까? 탈퇴 후 데이터는 복구할 수 없습니다.");
+                if (result) {
+                  alert("수고하셨어요! 2018년에도 화이팅!!");
+                }
               }}
             />
           </S.OptionButtonBox>

--- a/domain/Setting/SettingMaster/index.tsx
+++ b/domain/Setting/SettingMaster/index.tsx
@@ -1,6 +1,7 @@
+import { useRouter } from "next/router";
 import { useRecoilState } from "recoil";
 import Button from "../../../components/Button";
-import { UsersAvatarRemove, UsersAvatarUpload } from "../../../libs/oauth";
+import { UserRemove, UsersAvatarRemove, UsersAvatarUpload } from "../../../libs/oauth";
 import { loginUserState } from "../../../states/app";
 import { imageDefault } from "../../UserPage/UserProfile";
 import EditButton from "../EditButton";
@@ -9,6 +10,8 @@ import * as S from "./style";
 
 export default function SettingMaster(): JSX.Element {
   const [loginUser, setLoginUser] = useRecoilState(loginUserState);
+
+  const router = useRouter();
 
   async function loadAvatar(event: any) {
     try {
@@ -42,6 +45,15 @@ export default function SettingMaster(): JSX.Element {
       await UsersAvatarRemove();
     } catch (error) {
       alert("사용자 사진 삭제 중 에러: " + error);
+    }
+  }
+
+  async function removeUser() {
+    try {
+      await UserRemove();
+      router.replace("/");
+    } catch (error) {
+      alert("사용자 삭제 중 에러: " + error);
     }
   }
 
@@ -86,7 +98,7 @@ export default function SettingMaster(): JSX.Element {
               onClick={() => {
                 const result = confirm("회원 탈퇴를 진행하시겠습니까? 탈퇴 후 데이터는 복구할 수 없습니다.");
                 if (result) {
-                  alert("수고하셨어요! 2018년에도 화이팅!!");
+                  removeUser();
                 }
               }}
             />

--- a/domain/Setting/SettingMaster/index.tsx
+++ b/domain/Setting/SettingMaster/index.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { useRecoilValue } from "recoil";
+import { useRecoilState } from "recoil";
 import Button from "../../../components/Button";
+import { UsersAvatarUpload } from "../../../libs/oauth";
 import { loginUserState } from "../../../states/app";
 import { imageDefault } from "../../UserPage/UserProfile";
 import EditButton from "../EditButton";
@@ -8,7 +8,26 @@ import EditButton from "../EditButton";
 import * as S from "./style";
 
 export default function SettingMaster(): JSX.Element {
-  const loginUser = useRecoilValue(loginUserState);
+  const [loginUser, setLoginUser] = useRecoilState(loginUserState);
+
+  async function loadFile(event: any) {
+    try {
+      const target = event.target as HTMLInputElement;
+      const file = target.files[0];
+
+      // 낙관론적 업데이트
+      setLoginUser((prev) => {
+        return {
+          ...prev,
+          avatarImage: URL.createObjectURL(file),
+        };
+      });
+
+      await UsersAvatarUpload(file);
+    } catch (error) {
+      alert("사용자 사진 업로드 도중 에러: " + error);
+    }
+  }
 
   return (
     <S.Box>
@@ -21,7 +40,9 @@ export default function SettingMaster(): JSX.Element {
                 {
                   showText: "이미지 업로드",
                   onClick: () => {
-                    console.log("이미지 업로드 이벤트");
+                    const image = document.querySelector("#chooseFile");
+                    const ev = new MouseEvent("click", { bubbles: true });
+                    image.dispatchEvent(ev);
                   },
                 },
                 {
@@ -54,6 +75,7 @@ export default function SettingMaster(): JSX.Element {
           </S.OptionButtonBox>
         </S.SettingOptionBox>
       </S.SettingOptionListBox>
+      <input type="file" id="chooseFile" name="chooseFile" accept="image/*" style={{ display: "none" }} onChange={loadFile} />
     </S.Box>
   );
 }

--- a/domain/Setting/SettingMaster/style.ts
+++ b/domain/Setting/SettingMaster/style.ts
@@ -70,13 +70,14 @@ const ImageEditButtonBox = styled.div`
 const Line = styled.div`
   width: 100%;
   display: block;
-  margin: 36px 0px;
+  margin: 30px 0px;
   border-top: 2px solid ${({ theme }) => theme.lineColor.main};
 `;
 
 const SettingOptionListBox = styled.div`
   display: flex;
   flex-direction: column;
+  flex-flow: row-reverse;
   row-gap: 10px;
 `;
 const SettingOptionBox = styled.div`

--- a/libs/oauth/index.ts
+++ b/libs/oauth/index.ts
@@ -224,3 +224,30 @@ export async function UsersAvatarUpload(uploadedImage: File): Promise<void> {
     throw new Error("UsersAvatarUpload() 에러");
   }
 }
+
+export async function UsersAvatarRemove(): Promise<void> {
+  async function work() {
+    const accessToken = getLocalStorageAccessToken();
+    const { data } = await oauthClient.delete<UserInfo>(`/users/avatar`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return data;
+  }
+  try {
+    await work();
+  } catch (error) {
+    if (error instanceof Error) {
+      if (axios.isAxiosError(error)) {
+        switch (error.response?.status) {
+          case 401:
+            // 재시도: 리프레쉬 토큰으로 엑세스 토큰을 다시 발급
+            await TokenRefresh();
+            await work();
+        }
+      }
+    }
+    throw new Error("UsersAvatarRemove() 에러");
+  }
+}


### PR DESCRIPTION
# Feature

1. 로그인한 사용자의 프로필 사진을 업로드할 수 있는 기능이 추가되었습니다.
2. 로그인한 사용자가 회원 탈퇴를 할 수 있는 기능이 추가되었습니다.

# 테스트 시나리오

1. 카카오 혹은 자체 인증서버 로그인 후 설정페이지로 이동해서
   1. 업로드한 이미지가 정상적으로 표시되는지 확인합니다.
   1. 이미지 삭제 시 정상적으로 조회되지 않는지 확인합니다.
   1. 회원탈퇴 시 로그인한 계정으로 다시 로그인되지 않는지 확인합니다.